### PR TITLE
Pass convars as arguments when possible

### DIFF
--- a/src/entrypoint/nsconfig.go
+++ b/src/entrypoint/nsconfig.go
@@ -66,7 +66,11 @@ func (n *NSConfig) ApplyArgs(ax ...string) {
 
 		// shift and get the convar value
 		c, v, ax = x[1:], ax[0], ax[1:]
-		n.Set(c, v, "arg")
+		if _, ok := n.cv[c]; ok {
+			n.Set(c, v, "arg")
+		} else {
+			n.ax = append(n.ax, x, v)
+		}
 	}
 }
 


### PR DESCRIPTION
Apparently some convars can't be set in the autoexec file, meaning attempting to set them with `NS_EXTRA_ARGUMENTS` kinda breaks servers(?).

This PR fixes this behavior by always passing these extra convars to Northstar on the command-line, unless they're overriding a convar set by a builtin default or hardcoded environment variable.

For example, this means a command-line like:
```
-e NS_SERVER_NAME Test -e NS_EXTRA_ARGUMENTS="+ns_should_return_to_lobby 0 +map mp_glitch"
```
will set `ns_server_name` and `ns_should_return_to_lobby` in the autoexec file, and pass `+map mp_glitch` as command-line arguments.