### PR TITLE
Update Northstar to 1.4, adjust instance creation

### DIFF
--- a/src/entrypoint/nsinstance.go
+++ b/src/entrypoint/nsinstance.go
@@ -28,11 +28,10 @@ type NSInstance struct {
 	Output       io.Writer
 	InfoCallback InfoCallbackFunc
 
-	mu          sync.Mutex    // for reading the pointers, which are initialized when Run is called and not set again (DO NOT HOLD THIS LOCK FOR A LONG TIME)
-	terminated  chan struct{} // close when terminating
-	wait        chan struct{} // closed by run when the instance exits
-	launcherCmd *exec.Cmd
-	waiterCmd   *exec.Cmd
+	mu         sync.Mutex    // for reading the pointers, which are initialized when Run is called and not set again (DO NOT HOLD THIS LOCK FOR A LONG TIME)
+	terminated chan struct{} // close when terminating
+	wait       chan struct{} // closed by run when the instance exits
+	gameCmd    *exec.Cmd
 }
 
 // InfoCallbackFunc is function which will be called when the Northstar
@@ -130,7 +129,7 @@ func (n *NSInstance) Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pty, err := OpenPTY()
+	pty, err := setuppty()
 	if err != nil {
 		return fmt.Errorf("failed to allocate pty: %w", err)
 	}
@@ -146,22 +145,17 @@ func (n *NSInstance) Run() error {
 	}
 
 	xvfbResult := make(chan error, 1)
-	launcherResult := make(chan error, 1)
-	waiterResult := make(chan error, 1)
+	gameResult := make(chan error, 1)
 
 	n.mu.Lock()
-	n.launcherCmd = n.winecmd("wine64", append([]string{n.Executable, "-dedicated", "-multiple"}, n.Args...)...)
-	n.launcherCmd.Stdout = pty.Slave
-	n.launcherCmd.Stderr = pty.Slave
-	n.launcherCmd.Stdin = pty.Slave
-	n.launcherCmd.Env = append(n.launcherCmd.Env,
+	n.gameCmd = n.winecmd("wine64", append([]string{n.Executable, "-dedicated", "-multiple"}, n.Args...)...)
+	n.gameCmd.Stdout = pty.Slave
+	n.gameCmd.Stderr = pty.Slave
+	n.gameCmd.Stdin = pty.Slave
+	n.gameCmd.Env = append(n.gameCmd.Env,
 		"WINEPATH="+n.Dir,
 		"WINEDEBUG=fixme-secur32,fixme-bcrypt,fixme-ver,err-wldap32",
 	)
-	n.waiterCmd = n.winecmd("wineserver", "-w")
-	n.launcherCmd.Stdout = pty.Slave
-	n.launcherCmd.Stderr = pty.Slave
-	n.launcherCmd.Stdin = pty.Slave
 	n.mu.Unlock()
 
 	var xb bytes.Buffer
@@ -185,16 +179,16 @@ func (n *NSInstance) Run() error {
 		}()
 		time.Sleep(time.Second * 2)
 
-		n.launcherCmd.Env = append(n.launcherCmd.Env,
+		n.gameCmd.Env = append(n.gameCmd.Env,
 			"DISPLAY="+display,
 		)
 	}
 
-	if err := n.launcherCmd.Start(); err != nil {
-		return fmt.Errorf("failed to start launcher (%q, %q, %q): %w", n.Dir, n.Executable, n.Args, err)
+	if err := n.gameCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start game (%q, %q, %q): %w", n.Dir, n.Executable, n.Args, err)
 	}
 	go func() {
-		launcherResult <- n.launcherCmd.Wait()
+		gameResult <- n.gameCmd.Wait()
 	}()
 
 	const (
@@ -218,33 +212,12 @@ func (n *NSInstance) Run() error {
 			}
 			return fmt.Errorf("xvfb exited prematurely")
 
-		case err := <-launcherResult: // launcher exited (as of v1.3.0, it exits as soon as it starts tf2)
-			if err != nil {
-				return fmt.Errorf("failed to start launcher: %w", err)
-			}
-
+		case <-gameResult: // game exited
 			select {
 			case <-n.terminated:
 				return fmt.Errorf("server terminated")
 			default:
-			}
-
-			n.mu.Lock()
-			n.launcherCmd = n.winecmd("wineserver", "--wait")
-			n.mu.Unlock()
-
-			if err := n.waiterCmd.Start(); err != nil {
-				return fmt.Errorf("failed to wait for wine to exit: %w", err)
-			}
-			go func() {
-				waiterResult <- n.waiterCmd.Wait()
-			}()
-
-		case <-waiterResult: // waiter exited
-			select {
-			case <-n.terminated:
-				return fmt.Errorf("server terminated")
-			default:
+				close(n.terminated)
 				return fmt.Errorf("server exited")
 			}
 
@@ -353,20 +326,12 @@ func (n *NSInstance) sendTerminate(force bool) {
 	}
 
 	var (
-		launcher = n.launcherCmd != nil && n.launcherCmd.ProcessState != nil && !n.launcherCmd.ProcessState.Exited()
-		waiter   = n.waiterCmd != nil && n.waiterCmd.ProcessState != nil && !n.waiterCmd.ProcessState.Exited()
+		game = n.gameCmd != nil && n.gameCmd.ProcessState != nil && !n.gameCmd.ProcessState.Exited()
 	)
 
-	if launcher {
+	if game {
 		if force {
-			n.launcherCmd.Process.Signal(syscall.SIGKILL)
-		} else {
-			n.launcherCmd.Process.Signal(syscall.SIGTERM)
-		}
-	}
-
-	if launcher || waiter {
-		if force {
+			n.gameCmd.Process.Signal(syscall.SIGKILL)
 			n.winecmd("wineserver", "--kill").Start()
 		} else {
 			n.winecmd("wineboot", "--shutdown").Start()

--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.3.0
+pkgver=1.4.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
 
@@ -8,7 +8,7 @@ url="https://northstar.tf"
 license="MIT"
 
 arch="x86_64"
-source="https://github.com/R2Northstar/Northstar/releases/download/v${pkgver}/Northstar.release.v${pkgver}.zip"
+source="https://github.com/R2Northstar/Northstar/releases/download/v${pkgver}/Northstar.release.${pkgver}.zip"
 
 check() {
 	ls "$srcdir"
@@ -18,9 +18,10 @@ check() {
 
 package() {
 	rm "$srcdir"/*.zip
+	rm -rf "$srcdir/bin"
 	mkdir -p "$pkgdir/usr/lib/northstar"
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-29aab0227fa6af3fcf6d4ece1c878ccbad3ba5843f24570ea3f7cf592468d65b9c3c7af8fc9006892e0db1272abf93722026a48bbce511c043293a73dcb4f8e3  Northstar.release.v1.3.0.zip
+ecbbc95737e80e3a3f7ed8cefcb25ed604479ec5916e301070cce037db2658c6eb44c3cca6b8f10f89b6717ca46880a8c96fa1d8e73c4270834ebd00fdd642e1  Northstar.release.1.4.0.zip
 "


### PR DESCRIPTION
Sorry about the PR spam, not sure if you have something like this cooking already but this is hopefully at least useful for others using this image.

 - Updates the Northstar build file to use 1.4
 - Adjusts `NSInstance` logic to only abort when `NorthstarLauncher` exits instead of creating a watcher process, which isn't necessary anymore
 - Fixes what seems to be a deadlock when the launcher crashes, stopping the entrypoint from exiting (I'm not super sure if my fix is correct, but it does work)

I haven't added support for running NS commands with stdin, not totally sure how that would be set up with the custom PTY stuff?

Also apologies in advance, first time using Go 😄 