### PR TITLE
Set convars in autoexec if the value starts with a dash

### DIFF
--- a/src/entrypoint/nsconfig.go
+++ b/src/entrypoint/nsconfig.go
@@ -66,7 +66,7 @@ func (n *NSConfig) ApplyArgs(ax ...string) {
 
 		// shift and get the convar value
 		c, v, ax = x[1:], ax[0], ax[1:]
-		if _, ok := n.cv[c]; ok {
+		if _, ok := n.cv[c]; ok || strings.HasPrefix(v, "-") {
 			n.Set(c, v, "arg")
 		} else {
 			n.ax = append(n.ax, x, v)


### PR DESCRIPTION
**Issue:** Setting an extra argument to a value starting with a dash does not work, e.g.:

```sh
-e NS_EXTRA_ARGUMENTS="+slide_step_velocity_reduction -1000"
```

This ends up running the dedicated server like:

```sh
NorthstarLauncher.exe "+slide_step_velocity_reduction" "-1000"
```

The dedicated server is probably interpreting the `-1000` as a command-line flag, so it's ignored when parsing the actual args.

**Solution:** This PR forces convars to be set in the generated autoexec file if the value starts with a dash, ensuring the value is parsed as a number and not a flag.

One possible alternative is wrapping values in an extra pair of quotes, i.e.:

```sh
NorthstarLauncher.exe "+slide_step_velocity_reduction" "\"-1000\""
```

However the launcher doesn't seem to be capable of parsing values likes this.

updates #10