### PR TITLE
Bump pty column size to 1200 to prevent unnecessary line breaks

### DIFF
--- a/src/entrypoint/nsinstance.go
+++ b/src/entrypoint/nsinstance.go
@@ -426,7 +426,7 @@ func setuppty() (*PTY, error) {
 
 	if err := pty.SetWinsz(Winsize{
 		Row:    25,
-		Col:    120,
+		Col:    1200,
 		XPixel: 0,
 		YPixel: 0,
 	}); err != nil {


### PR DESCRIPTION
Took a look at my own logs of the day and it doesn't seems like there's many hits above 300 chars per lines (they do exist though).
I've set it to a much higher value since it apparently still plays nice with Wine and should cover just about everything..!

updates #11