### PR TITLE
Update Northstar to v1.13.1

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.13.0
+pkgver=1.13.1
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -27,5 +27,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-dea67e572d52764aeb90daf9136bbd0156c3af541c102268d17bb784b42165959b3a3f559efb5b4dd3cd0e4df7b1ffbb1a2a179f53a057f4c46006733d16b2fe  Northstar.release.v$pkgver.zip
+f6f97d05b026126878f5dff6651700f47853cd0723ccdf7ba7ffd92cd01414886b3f4fd80c4075dc7e259488d4d450719ce31e27bfe6aeeb15fce8f896714f85  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
Noticed that we didn't even updated to `v1.13.1` of Northstar yet.