### PR TITLE
Update Northstar to v1.14.2

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.14.1
+pkgver=1.14.2
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -26,5 +26,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-c56759f5d6ed86de0992549c886682d138db153507a3898ebc0e3c60e1e31a826a24fb4e8781404c951010c36112a195eaecec9eae7c181a336f5c47377cc99f  Northstar.release.v$pkgver.zip
+97b16b425ee0cf0eaae1280d09f59ddbe72a1d24c00d993150ace7a39eeca8428bfaa7188e39b47d225b8bcf5a50b6b6ac963ffb67c014effa01470b113b0bf3  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
https://github.com/R2Northstar/Northstar/releases/tag/v1.14.2

This contains an important bugfix that caused all Attrition servers since `v1.13.0` to crash.

Obligatory disclaimer that I did not test it.