### PR TITLE
Update Northstar to v1.18.1

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.18.0
+pkgver=1.18.1
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -26,5 +26,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-29dedb60ba87732efa6ad68b92c315e91a776c4814481c38b79b44dbf83ff7a885ec855b0f94687017971f40baf122e6652b1acbc1405a8655a1fb0198c35675  Northstar.release.v$pkgver.zip
+d7966094756da3ca0edbedb06d62699360aa80e0a8929726c80698f769c7100d536a461557fa5f5bc8890fdaf9e99a07303dc39b6858170ff546b9ff5c1e256d  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
Updates Northstar to release `v1.18.1`.

Obligatory disclaimer that I did not test it.