### PR TITLE
Update Northstar to v1.18.3

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.18.2
+pkgver=1.18.3
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -26,5 +26,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-51975dc68225be461086bbbae853815860d1fb3515a15ed706096e8b2904111e1c09e7b42f71dbefb84c4a498b9aa27443716dc8b1ef402691664e1bd293868d  Northstar.release.v$pkgver.zip
+70f8e41bde99e895700a1cd89d7c7ea0c0000e7df24e0a300b7bb40e8fc5facf83b30defd0a6cc277c4f10539409cdabba50ebcb22ae526b75a7244cccaad854  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
Updates Northstar to release `v1.18.3`.

Obligatory disclaimer that I did not test it.