### PR TITLE
Update Northstar to v1.19.6

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.19.5
+pkgver=1.19.6
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -26,5 +26,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-e4f6b7b1acf42452ac3ee4dab84e8bc13a81bf82690c8bd3e6ccf5543ff583faae01367c365c1f1c8d920adef666ba3f97fa80dd81e4b600847a73e35e674daa  Northstar.release.v$pkgver.zip
+25020f1c46d03471c5e88794b2857cb260250272cc2e572556366f6d2077260520821f146a41f3166144c000e07301ce4a1a28b759ecf8e0d4a435d451a6a0f1  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
Updates Northstar to release `v1.19.6`.

Obligatory disclaimer that I did not test it.