### PR TITLE
Update Northstar to v1.19.11

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.19.10
+pkgver=1.19.11
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -26,5 +26,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-e2111718708a69b93161f786c296d6436dcca9045fe0afa1019da1ac63f06f61cb562066c64a8bee9b2241005a25408c195301c81c6174805bcb4116d69ea532  Northstar.release.v$pkgver.zip
+8f95877d9206769ac6e90f474b17241a7e84d38a6456cf0146173004a119bbf53f77cc376204fdcd9294d89b14ef1f4f4d6268cc3934d743d9ce62af5cde54be  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
Updates Northstar to release `v1.19.11`.

Obligatory disclaimer that I did not test it.