### PR TITLE
Update Northstar to v1.20.1

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.20.0
+pkgver=1.20.1
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -26,5 +26,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-195399093395efe5a51fbf1f8f1f710696e6add1739b2ac27df6243658cf0f290fe2cfdaed2ba807f7bacfe6b0b986553d70ad41506cefbdcc3aaf470dc32af2  Northstar.release.v$pkgver.zip
+19de6f899f51e4267ce7e3550649e912384fd3e35be84b701a81fd470ec9fc57a7f00620dee3892c7f48b2110d88e00ddf960640fa10762df382852fb89d2185  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
Updates Northstar to release `v1.20.1`.

Obligatory disclaimer that I did not test it.