### PR TITLE
Update Northstar to v1.21.3

### DIFF
--- a/src/northstar/APKBUILD
+++ b/src/northstar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: pg9182 <96569817+pg9182@users.noreply.github.com>
 pkgname=northstar
-pkgver=1.21.2
+pkgver=1.21.3
 pkgver_tf=2.0.11.0
 pkgrel=0
 pkgdesc="Northstar binaries and mods"
@@ -26,5 +26,5 @@ package() {
 	cp -r "$srcdir/." "$pkgdir/usr/lib/northstar/"
 }
 sha512sums="
-ff925413da2bb8e3c3e2246dfd02e3403479cb31d0ca58ea9c915df5fa3b71846cb8e526fb3e7ccbdbe8db86e369f60203ae158e43c8baab04559a325ea05702  Northstar.release.v$pkgver.zip
+d22fe9911ffdfb456b5fc4a42b5fb46e4a35f4a95c0df3a71563b525c1ddcba4fc9c24f392edd189637b0070f61cefabe3b41780292dfd806f7de194cb1ebd3f  Northstar.release.v$pkgver.zip
 "


### PR DESCRIPTION
Updates Northstar to release `v1.21.3`.

Obligatory disclaimer that I did not test it.